### PR TITLE
Fix: ESLint prefer-const issue in hero/bg-helper.ts

### DIFF
--- a/src/components/hero/bg-helper.ts
+++ b/src/components/hero/bg-helper.ts
@@ -5,7 +5,7 @@ export const buildBackgroundStyle = (
 ): React.CSSProperties => {
   if (!bg) return {};
 
-  let styles: React.CSSProperties = {
+  const styles: React.CSSProperties = {
     position: "absolute",
     inset: 0,
     width: "100%",


### PR DESCRIPTION
### Summary
This PR fixes a linting error caused by the `prefer-const` rule in `src/components/hero/bg-helper.ts`.

### Changes
- Replaced `let` with `const` for the `styles` variable.
- Ensured code passes ESLint checks successfully.

### Impact
- No functional change, only code quality improvement.
- Fixes build failure on Vercel.
