### PR TITLE
fix(hero): resolved image optimization issue and height bug with next/image

### DIFF
--- a/src/app/[[...slug]]/page.tsx
+++ b/src/app/[[...slug]]/page.tsx
@@ -5,6 +5,9 @@ import pagesData from "@/data/page.json";
 import { signOut, useSession } from "next-auth/react";
 import Link from "next/link";
 import NotFoundPage from "../not-found";
+import Hero from "@/components/hero/Hero";
+import { centerHero, formHero, shapeDividerHero, splitHero, statsHero, videoHero } from "@/components/hero/defaults";
+import StatsVariant from "@/components/hero/variants/StatsVariant";
 
 export default function ClientPage({ params }: { params: { slug?: string[] } }) {
   const session = useSession();
@@ -45,7 +48,12 @@ export default function ClientPage({ params }: { params: { slug?: string[] } }) 
       <h1>Editor - TDACorp</h1>
       <pre>{JSON.stringify(session, null, 2)}</pre>
 
-     
+     <Hero schema={splitHero}/>
+     <Hero schema={centerHero}/>
+     <Hero schema={formHero}/>
+     <Hero schema={shapeDividerHero}/>
+     <Hero schema={statsHero}/>
+     <Hero schema={videoHero}/>
     </main>
   );
 }

--- a/src/components/hero/HeroMedia.tsx
+++ b/src/components/hero/HeroMedia.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import { HeroProps } from "./types";
+import Image from "next/image";
 
 const HeroMedia: React.FC<HeroProps> = ({
   image,
@@ -24,26 +25,34 @@ const HeroMedia: React.FC<HeroProps> = ({
     );
   }
 
-  if (image) {
+  if (image && !imgError) {
     const src = Array.isArray(image) ? image[0] : image;
     return (
-      <img
-        src={src}
-        alt={altText || "hero-image"}
-        className="w-full h-auto rounded-2xl"
-        onError={() => setImgError(true)}
-      />
+      <div className="relative w-full aspect-[16/9] rounded-2xl overflow-hidden">
+        <Image
+          src={src}
+          alt={altText || "hero-image"}
+          fill
+          className="object-cover rounded-2xl"
+          sizes="(max-width: 768px) 100vw, 50vw"
+          onError={() => setImgError(true)}
+        />
+      </div>
     );
   }
 
   if (illustration) {
     const src = illustration || "https://images.pexels.com/photos/16347225/pexels-photo-16347225.jpeg";
     return (
-      <img
-        src={src}
-        alt={altText || "hero-illustration"}
-        className="w-full h-auto"
-      />
+      <div className="relative w-full aspect-[16/9]">
+        <Image
+          src={src}
+          alt={altText || "hero-illustration"}
+          width={800}
+          height={600}
+          className="object-contain"
+        />
+      </div>
     );
   }
 


### PR DESCRIPTION
#### 🐛 Bug

* Using the native `<img>` tag triggered the ESLint rule `@next/next/no-img-element`.
* This could lead to **slower LCP** (Largest Contentful Paint) and **higher bandwidth usage**.
* Additionally, when using `next/image` with the `fill` prop, the parent container had no defined height, causing layout shift and console warnings.

#### 🔧 Fix

* Replaced `<img>` with **Next.js `<Image />`** component for automatic optimization.
* Added `aspect-[16/9]` and responsive height handling to fix image layout and ratio issues.
* Ensured smoother rendering and improved performance metrics (LCP).

#### ✅ Result

* No more `@next/next/no-img-element` warnings.
* Hero section images now render correctly with proper aspect ratio and optimized loading.
* Improved performance and visual stability.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added six new hero layout variations including split, center, form, shape divider, stats, and video options for enhanced page design flexibility.

* **Improvements**
  * Optimized image rendering with improved responsiveness and better error handling for hero images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->