### PR TITLE
fix(heading): use className prop to resolve ESLint warning and improve styling flexibility

### DIFF
--- a/src/components/heading/Heading.tsx
+++ b/src/components/heading/Heading.tsx
@@ -32,5 +32,5 @@ export const Heading: React.FC<HeadingSchema> = ({
     transition: tokens.transitions.default,
   };
 
-  return <Tag style={styles}>{content}</Tag>;
+  return <Tag style={styles} className={className} >{content}</Tag>;
 };


### PR DESCRIPTION
### Summary
This PR fixes an ESLint warning in the `Heading` component where the `className` prop was declared but not used.  
The prop is now properly applied to the rendered <Tag> element.

### Changes
- Added `className` attribute to the rendered heading tag.
- Resolved `@typescript-eslint/no-unused-vars` warning.
- Improved styling flexibility for external class-based customization.

### Testing
- Verified that all heading levels (h1–h6) render correctly.
- Confirmed no new ESLint warnings.
- Confirmed custom className styles are applied successfully.

### Impact
Improves maintainability, code quality, and consistency across styled components.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Heading component now correctly applies custom styling options alongside default styles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->